### PR TITLE
very little script to clean the csv into a valid 2i for the emulator

### DIFF
--- a/cleanupcsv
+++ b/cleanupcsv
@@ -1,0 +1,10 @@
+##!/bin/sh
+
+
+##usage:
+
+# IMPORTANT! do not use ";" in any of the cells which are chronological before your cells with the 25bits
+# export your csv with ";" as seperator.
+# ./cleanupcsv origin.csv target.2i (be careful not to override your origin ;)
+
+awk -F ";" '{print $14":"$15,$16,$17,$18,$19,$20,$21,$22,$23,$24,$25,$26}' $1 | egrep "([0-9]){5}:([0-9])+" > $2;


### PR DESCRIPTION
I am not sure if it's necessary to have such a one line script in the repo, because 
everyone could write their own really fast. However i saw lots of groups copy the 25 bits binaries out of the csv manually or even typing the binaries inside a new textfile (without the use of the cool ods template).
Because of that it is probably useful for several groups which use the emulator. At least for us it was very useful :)