### PR TITLE
Write error messages to stderr instead of stdout

### DIFF
--- a/src/cli/ipg.rs
+++ b/src/cli/ipg.rs
@@ -9,11 +9,11 @@ pub fn main(args: &ArgMatches<'_>) -> Result<(), i32> {
     // Load the program from the given path
     let program_path = Path::new(args.value_of("2i-programm").unwrap());
     let program_file = File::open(program_path).map_err(|e| {
-        println!("Die angegebene Datei konnte nicht geöffnet werden: {}", e);
+        eprintln!("Die angegebene Datei konnte nicht geöffnet werden: {}", e);
         2
     })?;
     let program = read_reachable_program(&program_file).map_err(|e| {
-        println!("Das Mikroprogramm konnte nicht geladen werden: {}", e);
+        eprintln!("Das Mikroprogramm konnte nicht geladen werden: {}", e);
         3
     })?;
 

--- a/src/cli/latex.rs
+++ b/src/cli/latex.rs
@@ -13,11 +13,11 @@ pub fn main(args: &ArgMatches<'_>) -> Result<(), i32> {
     let programs = args.values_of("2i-programm").unwrap().map(|arg| {
         let program_path = Path::new(arg);
         let program_file = File::open(program_path).map_err(|e| {
-            println!("Die angegebene Datei konnte nicht geöffnet werden: {}", e);
+            eprintln!("Die angegebene Datei konnte nicht geöffnet werden: {}", e);
             2
         })?;
         let program = read_reachable_program(&program_file).map_err(|e| {
-            println!("Das Mikroprogramm konnte nicht geladen werden: {}", e);
+            eprintln!("Das Mikroprogramm konnte nicht geladen werden: {}", e);
             3
         })?;
 

--- a/src/cli/main.rs
+++ b/src/cli/main.rs
@@ -125,7 +125,7 @@ fn _main() -> Result<(), i32> {
     Ok(())
 }
 
-/// Load 2i program from path and print errors to stdout if it failes
+/// Load 2i program from path and print errors to stdout if it fails
 fn load_programm(path: &Path) -> Result<Program, ()> {
     if let Ok(file) = File::open(&path) {
         match emulator::parse::read_program(file) {


### PR DESCRIPTION
When using the `ipg-csv` or the `latex` subcommand like this
```
daniel@host:~$ 2i-emulator ipg-csv nonexistant.2i > test.csv
daniel@host:~$ cat test.csv
Die angegebene Datei konnte nicht geöffnet werden: Das System kann die angegebene Datei nicht finden. (os error 2)
```
any errors will go unnoticed because both normal output and errors get written to `stdout`.

Writing errors to `stderr` fixes that and the output would look like this:
```
daniel@host:~$ 2i-emulator ipg-csv nonexistant.2i > test.csv
Die angegebene Datei konnte nicht geöffnet werden: Das System kann die angegebene Datei nicht finden. (os error 2)
```

Writing errors to `stdout` in interactive mode is fine IMHO.